### PR TITLE
Remove add_reaction for onReactionAdded in docs

### DIFF
--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -3431,7 +3431,6 @@ class Client(object):
         Args:
             mid: Message ID, that user reacted to
             reaction (MessageReaction): Reaction
-            add_reaction: Whether user added or removed reaction
             author_id: The ID of the person who reacted to the message
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`


### PR DESCRIPTION
Seems like it was leftover from some other function, probably one to handle both Added and Removed :)